### PR TITLE
fix_13

### DIFF
--- a/src/style_changes.ts
+++ b/src/style_changes.ts
@@ -45,10 +45,12 @@ export function styleChange() {
   notionFrame.style.maxWidth = "60%"; // <- ""
 
   const notionPageContent = document.querySelector(consts.NOTION_PAGE_CONTENT_PATH) as HTMLElement;
-  const children = Array.from(notionPageContent.children) as HTMLElement[];
-  for (const child of children) {
-    child.style.width = "calc(60vw - 10px)"; // <- "calc(100vw - 10px)"
-    child.style.maxWidth = "calc(60vw - 10px)"; // <- "calc(100vw - 10px)"
+  if (notionPageContent) {
+    const children = Array.from(notionPageContent.children) as HTMLElement[];
+    for (const child of children) {
+      child.style.width = "calc(60vw - 10px)"; // <- "calc(100vw - 10px)"
+      child.style.maxWidth = "calc(60vw - 10px)"; // <- "calc(100vw - 10px)"
+    }
   }
 
   const headbar = document.querySelector(consts.HEAD_BAR_PATH) as HTMLElement;
@@ -86,12 +88,7 @@ export function undoStyleChange() {
   const notionFrame = document.querySelector(consts.NOTION_FRAME_PATH) as HTMLElement;
   notionFrame.style.maxWidth = "";
 
-  const notionPageContent = document.querySelector(consts.NOTION_PAGE_CONTENT_PATH) as HTMLElement;
-  const children = Array.from(notionPageContent.children) as HTMLElement[];
-  for (const child of children) {
-    child.style.width = "calc(100vw - 10px)";
-    child.style.maxWidth = "calc(100vw - 10px)";
-  }
+  window.resizeBy(screen.width, screen.height);
 
   const headbar = document.querySelector(consts.HEAD_BAR_PATH) as HTMLElement;
   headbar.style.zIndex = "100";


### PR DESCRIPTION
# PR: [fix_13]

## ⭐ Overview

インラインデータベースを内包するページを開いているときに、左サイドメニューと、サイドパネルを同時に開いても、左サイドメニューにページの内容が隠れないようにした。

![スクリーンショット 2022-07-12 18 15 46](https://user-images.githubusercontent.com/8337910/178455803-dbd61220-75b0-4c25-b1c7-2c9e49af32ac.png)

## 🤔 How to fix bugs and enhance functionality

`child.style.width = "calc(60vw - 10px)";`
上記、ページ内のコンテンツの幅を変更する処理を、`if (notionPageContent) {}`で包んで不用意に乱発するのを防いだ。

また、`undoStyleChange`に`window.resizeBy(screen.width, screen.height);`を加えた。
この処理を行うと、Notion側の「ウィンドウサイズが変更されると、丁度良く幅を調整する」を発火させることができる。

## 📂 Details of Changes

- src/style_changes.ts

## 🐙 Related Issues

#13

## 💬 Others
