### PR TITLE
Add option page

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,6 +5,10 @@
   "description": "When you open a Database item in Notion, it will appear in the sidepanel.",
   "version": "1.1.0",
 
+  "options_ui": {
+    "page": "options.html"
+  },
+
   "action": {
     "default_icon": {
       "16": "16.png",
@@ -22,5 +26,5 @@
     }
   ],
 
-  "permissions": []
+  "permissions": ["storage"]
 }

--- a/public/options.html
+++ b/public/options.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>My Test Extension Options</title>
+    <script src="js/vendor.js"></script>
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script src="js/options.js"></script>
+  </body>
+</html>

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from "react";
+import ReactDOM from "react-dom";
+import "./styles/options.scss";
+
+const Options = () => {
+  const [highlightFlg, setHighlight] = useState<boolean>(false);
+  const [status, setStatus] = useState<string>("");
+
+  useEffect(() => {
+    chrome.storage.local.get(
+      {
+        highlight: true,
+      },
+      (items) => {
+        setHighlight(items.highlight);
+      }
+    );
+  }, []);
+
+  const saveOptions = () => {
+    chrome.storage.local.set(
+      {
+        highlight: highlightFlg,
+      },
+      () => {
+        setStatus("Saved! Please reload the screen to reflect.");
+        const id = setTimeout(() => {
+          setStatus("");
+        }, 3000);
+        return () => clearTimeout(id);
+      }
+    );
+  };
+
+  return (
+    <>
+      <div className="field">
+        <div className="labelText">Highlight open items in the side panel</div>
+        <div className="switch">
+          <input
+            id="toggle"
+            className="toggleInput"
+            type="checkbox"
+            checked={highlightFlg}
+            onChange={(event) => setHighlight(event.target.checked)}
+          />
+          <label htmlFor="toggle" className="toggleLabel" />
+        </div>
+      </div>
+      <hr></hr>
+      <div className="saveField">
+        <div className="buttonWrap">
+          <button className="saveButton" onClick={saveOptions}>
+            Save
+          </button>
+        </div>
+        <div className="statusText">{status}</div>
+      </div>
+    </>
+  );
+};
+
+ReactDOM.render(
+  <React.StrictMode>
+    <Options />
+  </React.StrictMode>,
+  document.getElementById("root")
+);

--- a/src/style_changes.ts
+++ b/src/style_changes.ts
@@ -68,14 +68,18 @@ export function styleChange() {
     helpButton.insertAdjacentHTML("beforebegin", consts.CLOSE_BUTTON);
   }
 
-  const allBlocks = mainBody.querySelectorAll<HTMLElement>(`[data-block-id]`);
-  for (const block of allBlocks) {
-    block.style.border = "";
-  }
-  getDataBlockId().then((dataBlockId) => {
-    const targetBlocks = mainBody.querySelectorAll<HTMLElement>(`[data-block-id="${dataBlockId}"]`);
-    for (const targetBlock of targetBlocks) {
-      targetBlock.style.border = "0.2rem solid red";
+  chrome.storage.local.get("highlight").then((items) => {
+    if (items.highlight) {
+      const allBlocks = mainBody.querySelectorAll<HTMLElement>(`[data-block-id]`);
+      for (const block of allBlocks) {
+        block.style.border = "";
+      }
+      getDataBlockId().then((dataBlockId) => {
+        const targetBlocks = mainBody.querySelectorAll<HTMLElement>(`[data-block-id="${dataBlockId}"]`);
+        for (const targetBlock of targetBlocks) {
+          targetBlock.style.border = "0.2rem solid red";
+        }
+      });
     }
   });
 }
@@ -85,11 +89,15 @@ export function undoStyleChange() {
    * Revert changes made with `styleChange`.
    */
 
-  const mainBody = document.querySelector(consts.MAIN_BODY_PATH) as HTMLElement;
-  const allBlocks = mainBody.querySelectorAll<HTMLElement>(`[data-block-id]`);
-  for (const block of allBlocks) {
-    block.style.border = "";
-  }
+  chrome.storage.local.get("highlight").then((items) => {
+    if (items.highlight) {
+      const mainBody = document.querySelector(consts.MAIN_BODY_PATH) as HTMLElement;
+      const allBlocks = mainBody.querySelectorAll<HTMLElement>(`[data-block-id]`);
+      for (const block of allBlocks) {
+        block.style.border = "";
+      }
+    }
+  });
 
   const overlayBody = document.querySelector(consts.OVERLAY_BODY_PATH) as HTMLElement;
   const closePanel = document.querySelector(consts.CLOSE_PANEL_PATH) as HTMLElement;

--- a/src/styles/options.scss
+++ b/src/styles/options.scss
@@ -1,0 +1,64 @@
+input {
+  position: absolute;
+  left: 0rem;
+  top: 0rem;
+  z-index: 1;
+  opacity: 0;
+  cursor: pointer;
+}
+
+label {
+  cursor: pointer;
+  width: 2rem;
+  height: 1rem;
+  background: #ccc;
+  position: relative;
+  display: inline-block;
+  border-radius: 4.6rem;
+  transition: 0.4s;
+  box-sizing: border-box;
+  &:after {
+    content: "";
+    position: absolute;
+    width: 1.1rem;
+    height: 1.1rem;
+    border-radius: 100%;
+    left: 0;
+    top: 0;
+    z-index: 2;
+    background: #fff;
+    box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.2);
+    transition: 0.4s;
+  }
+}
+
+input:checked {
+  + label {
+    background-color: #4bd865;
+    &:after {
+      left: 1rem;
+    }
+  }
+}
+
+.field {
+  right: 0rem;
+  position: relative;
+  margin: auto;
+  display: flex;
+  justify-content: space-around;
+}
+
+.labelText {
+  margin-top: 0.1rem;
+}
+
+.saveField {
+  margin: auto;
+  display: flex;
+}
+
+.statusText {
+  margin: auto;
+  color: darkgreen;
+}

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -5,6 +5,7 @@ const srcDir = path.join(__dirname, "..", "src");
 module.exports = {
   entry: {
     content_script: path.join(srcDir, "content_script.ts"),
+    options: path.join(srcDir, "options.tsx"),
   },
   output: {
     path: path.join(__dirname, "../dist/js"),


### PR DESCRIPTION
# PR: Add option page

## ⭐ Overview

オプションページを実装。
またそれに伴い、 https://github.com/sahksas/notion_sidepanel/pull/12 のON,Offをオプションページで行えるようにした。

![スクリーンショット 2022-07-16 17 24 22](https://user-images.githubusercontent.com/8337910/179347092-de4f4f9a-9f43-4b72-8fdc-055a87243b58.png)

## 🤔 How to fix bugs and enhance functionality

`chrome.storage`からの値の取得、オプションページの表示をReactで実装。
Notionでスタイルの変更を行う関数の中で`if (items.highlight) {}`の条件分岐を追加した。

## 📂 Details of Changes

### オプションページと、そのスタイルを実装
- public/manifest.json
- public/options.html
- src/options.tsx
- src/styles/options.scsswebpack/webpack.common.js

### `permissions`へ`storege`を追加
- public/manifest.json

### `chrome.storage`が持つ値によって、画面の表示が分岐する処理を追加
- src/style_changes.ts

## 🐙 Related Issues

#15

## 💬 Others
